### PR TITLE
General code clean-ups:

### DIFF
--- a/pyjab/accessibleinfo.py
+++ b/pyjab/accessibleinfo.py
@@ -176,7 +176,7 @@ class AccessibleKeyBindings(Structure):
     ]
 
 
-class VisibleChildenInfo(Structure):
+class VisibleChildrenInfo(Structure):
     _fields_ = [
         ("returnedChildrenCount", c_int),
         ("children", JOBJECT64 * MAX_VISIBLE_CHILDREN),

--- a/pyjab/common/actorscheduler.py
+++ b/pyjab/common/actorscheduler.py
@@ -31,8 +31,7 @@ class ActorScheduler:
         """
         Send a message to a named actor
         """
-        actor = self.actors.get(name)
-        if actor:
+        if actor := self.actors.get(name):
             self.logger.debug("send msg '{}' to actor '{}'".format(msg, actor))
             self.msg_queue.append((actor, msg))
 

--- a/pyjab/common/service.py
+++ b/pyjab/common/service.py
@@ -34,7 +34,7 @@ class Service(object):
             try:
                 data = fp.read()
             except (OSError, IOError):
-                self.logger.error("bridge is not enable")
+                self.logger.error("bridge is not enabled")
                 return False
         is_enabled = data == A11Y_PROPS_CONTENT
         self.logger.debug("is bridge enabled => '{}'".format(is_enabled))

--- a/pyjab/common/service.py
+++ b/pyjab/common/service.py
@@ -25,7 +25,7 @@ class Service(object):
                 self.logger.debug("enable bridge")
                 fp.write(A11Y_PROPS_CONTENT)
             except (OSError, IOError):
-                self.logger.error("enable bridge is failed")
+                self.logger.error("enable bridge failed")
 
     def is_bridge_enabled(self) -> bool:
         if not Path(A11Y_PROPS_PATH).is_file():

--- a/pyjab/common/textreader.py
+++ b/pyjab/common/textreader.py
@@ -6,12 +6,12 @@ from typing import Optional
 class TextReader(object):
     """Text reader for retrieve text or transfer text in different types."""
 
+    @staticmethod
     def get_text_from_raw_bytes(
-        self,
-        buffer: bytes,
-        chars_len: int,
-        encoding: Optional[str] = None,
-        errors_fallback: str = "replace",
+            buffer: bytes,
+            chars_len: int,
+            encoding: Optional[str] = None,
+            errors_fallback: str = "replace",
     ) -> str:
         """[summary]
 

--- a/pyjab/common/win32utils.py
+++ b/pyjab/common/win32utils.py
@@ -1,6 +1,6 @@
 import time
 from ctypes.wintypes import HWND
-from typing import Dict, Generator, List
+from typing import Dict, Generator, List, Optional
 import pythoncom
 import win32api
 import win32clipboard
@@ -227,7 +227,7 @@ class Win32Utils(object):
         win32gui.EnumWindows(get_all_hwnds, 0)
         return dict_hwnd
 
-    def get_hwnd_by_title(self, title: str) -> HWND:
+    def get_hwnd_by_title(self, title: str) -> Optional[HWND]:
         dict_hwnd = self.enum_windows()
         try:
             return list(dict_hwnd.keys())[list(dict_hwnd.values()).index(title)]
@@ -236,11 +236,7 @@ class Win32Utils(object):
 
     def get_hwnds_by_title(self, title: str) -> List[HWND]:
         dict_hwnd = self.enum_windows()
-        hwnds = list()
-        for hwnd, win_title in dict_hwnd.items():
-            if title == win_title:
-                hwnds.append(hwnd)
-        return hwnds
+        return [hwnd for hwnd, win_title in dict_hwnd.items() if title == win_title]
 
     def get_title_by_hwnd(self, hwnd: HWND) -> str:
         return win32api.GetWindowText(hwnd)
@@ -249,8 +245,7 @@ class Win32Utils(object):
         latest_log = ""
         start = time.time()
         while True:
-            hwnd = self.get_hwnd_by_title(title)
-            if hwnd:
+            if hwnd := self.get_hwnd_by_title(title):
                 return hwnd
             error_log = f"no hwnd found by win title =>'{title}'"
             if latest_log != error_log:

--- a/pyjab/common/xpathparser.py
+++ b/pyjab/common/xpathparser.py
@@ -49,7 +49,7 @@ class XpathParser(object):
             raise XpathParserException(
                 "no contents found conditions '{}'".format(contents)
             )
-        attributes = list()
+        attributes = []
         for content in contents:
             name, value = content[0][1:].split(sep="=", maxsplit=1)
             attributes.append(dict(name=name, value=value))

--- a/pyjab/jabdriver.py
+++ b/pyjab/jabdriver.py
@@ -234,8 +234,7 @@ class JABDriver(object):
         """
         start = time()
         while True:
-            hwnd = self.get_java_window_hwnd(title=title)
-            if hwnd:
+            if hwnd := self.get_java_window_hwnd(title=title):
                 return hwnd
             log_out = f"no java window found by title '{title}'"
             if self.latest_log != log_out:
@@ -359,7 +358,7 @@ class JABDriver(object):
         """
         Find list of JABElement given a name locator.
         """
-        jabelements = list()
+        jabelements = []
         if value == self.root_element.name:
             jabelements.append(self.root_element)
         jabelements.extend(
@@ -373,7 +372,7 @@ class JABDriver(object):
         """
         Find list of JABElement given a description locator.
         """
-        jabelements = list()
+        jabelements = []
         if value == self.root_element.description:
             jabelements.append(self.root_element)
         jabelements.extend(
@@ -387,7 +386,7 @@ class JABDriver(object):
         """
         Find list of JABElement given a role locator.
         """
-        jabelements = list()
+        jabelements = []
         if value == self.root_element.role:
             jabelements.append(self.root_element)
         jabelements.extend(
@@ -401,7 +400,7 @@ class JABDriver(object):
         """
         Find list of JABElement given a states locator.
         """
-        jabelements = list()
+        jabelements = []
         if value == self.root_element.states:
             jabelements.append(self.root_element)
         jabelements.extend(
@@ -415,7 +414,7 @@ class JABDriver(object):
         """
         Find list of JABElement given a object depth locator.
         """
-        jabelements = list()
+        jabelements = []
         if value == self.root_element.object_depth:
             jabelements.append(self.root_element)
         jabelements.extend(
@@ -431,7 +430,7 @@ class JABDriver(object):
         """
         Find list of JABElement given a children count locator.
         """
-        jabelements = list()
+        jabelements = []
         if value == self.root_element.children_count:
             jabelements.append(self.root_element)
         jabelements.extend(
@@ -447,7 +446,7 @@ class JABDriver(object):
         """
         Find list of JABElement given a index in parent locator.
         """
-        jabelements = list()
+        jabelements = []
         if value == self.root_element.index_in_parent:
             jabelements.append(self.root_element)
         jabelements.extend(
@@ -511,8 +510,7 @@ class JABDriver(object):
                     f"JABElement with locator '{by}' '{value}' does not found in {timeout} seconds"
                 )
             try:
-                jabelement = self.find_element(by=by, value=value)
-                return jabelement
+                return self.find_element(by=by, value=value)
             except JABException:
                 log_out = f"JABElement with locator '{by}' '{value}' does not found"
                 if self.latest_log != log_out:
@@ -549,7 +547,7 @@ class JABDriver(object):
         y = bounds.get("y")
         width = bounds.get("width")
         height = bounds.get("height")
-        im = ImageGrab.grab(
+        return ImageGrab.grab(
             bbox=(
                 x,
                 y,
@@ -559,7 +557,6 @@ class JABDriver(object):
             include_layered_windows=False,
             all_screens=True,
         )
-        return im
 
     def set_window_size(self, width, height):
         """

--- a/pyjab/jabelement.py
+++ b/pyjab/jabelement.py
@@ -4,7 +4,7 @@ from pyjab.common.textreader import TextReader
 import re
 from ctypes import Array, byref, CDLL, c_char, c_long, create_string_buffer
 from ctypes.wintypes import HWND
-from typing import Any, Generator
+from typing import Any, Generator, Optional
 from PIL import Image, ImageGrab
 from pyjab.common.by import By
 from pyjab.common.exceptions import JABException
@@ -199,11 +199,10 @@ class JABElement(object):
         Yields:
             Generator: Generator of all child jab elements from this parent jab element.
         """
-        jabelement = (
-            jabelement
-            if jabelement
-            else JABElement(self.bridge, self.hwnd, self.vmid, self.accessible_context)
+        jabelement = jabelement or JABElement(
+            self.bridge, self.hwnd, self.vmid, self.accessible_context
         )
+
         for jabelement in self._generate_childs_from_element(
             jabelement=jabelement, visible=visible
         ):
@@ -227,11 +226,10 @@ class JABElement(object):
         Yields:
             Generator: Generator of child jab elements from this parent jab element.
         """
-        jabelement = (
-            jabelement
-            if jabelement
-            else JABElement(self.bridge, self.hwnd, self.vmid, self.accessible_context)
+        jabelement = jabelement or JABElement(
+            self.bridge, self.hwnd, self.vmid, self.accessible_context
         )
+
         if visible:
             children_count = self._get_visible_children_count(
                 jabelement.accessible_context
@@ -275,17 +273,13 @@ class JABElement(object):
 
     def _request_focus(self, accessible_context: JOBJECT64 = None) -> None:
         """Request focus for a component. Returns whether successful."""
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         self.bridge.requestFocus(self.vmid, accessible_context)
 
     def _get_accessible_selection_from_context(
         self, accessible_context: JOBJECT64 = None
     ) -> JOBJECT64:
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         return self.bridge.getAccessibleSelectionFromContext(
             self.vmid, accessible_context, 0
         )
@@ -293,9 +287,7 @@ class JABElement(object):
     def _add_accessible_selection_from_context(
         self, index: int, accessible_context: JOBJECT64 = None
     ) -> None:
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         self.bridge.addAccessibleSelectionFromContext(
             self.vmid, accessible_context, index
         )
@@ -303,9 +295,7 @@ class JABElement(object):
     def _clear_accessible_selection_from_context(
         self, accessible_context: JOBJECT64
     ) -> None:
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         self.bridge.clearAccessibleSelectionFromContext(self.vmid, accessible_context)
 
     def _is_same_object(self, obj1: JOBJECT64, obj2: JOBJECT64) -> bool:
@@ -334,9 +324,7 @@ class JABElement(object):
         Returns:
             JOBJECT64: Top level object.
         """
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         top_object = self.bridge.getTopLevelObject(self.vmid, accessible_context)
         if top_object == 0:
             raise JABException(self.int_func_err_msg.format("getTopLevelObject"))
@@ -353,9 +341,7 @@ class JABElement(object):
         Returns:
             JOBJECT64: Parent Accessible Context.
         """
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         return self.bridge.getAccessibleParentFromContext(self.vmid, accessible_context)
 
     def _get_accessible_context_info(
@@ -373,9 +359,7 @@ class JABElement(object):
             AccessibleContextInfo: Accessible Context Info.
         """
         info = AccessibleContextInfo()
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getAccessibleContextInfo(
             self.vmid, accessible_context, byref(info)
         )
@@ -397,9 +381,7 @@ class JABElement(object):
         Returns:
             int: Object depth.
         """
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         object_depth = self.bridge.getObjectDepth(self.vmid, accessible_context)
         if object_depth == -1:
             raise JABException(self.int_func_err_msg.format("getObjectDepth"))
@@ -409,9 +391,7 @@ class JABElement(object):
         self, accessible_context: JOBJECT64 = None
     ) -> AccessibleTextInfo:
         info = AccessibleTextInfo()
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getAccessibleTextInfo(
             self.vmid, accessible_context, byref(info), 0, 0
         )
@@ -427,9 +407,7 @@ class JABElement(object):
         length: int,
         accessible_context: JOBJECT64 = None,
     ) -> None:
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getAccessibleTextRange(
             self.vmid, accessible_context, start, end, text, length
         )
@@ -452,9 +430,7 @@ class JABElement(object):
             AccessibleTableInfo: Accessible Table Info.
         """
         info = AccessibleTableInfo()
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getAccessibleTableInfo(
             self.vmid, accessible_context, byref(info)
         )
@@ -477,9 +453,7 @@ class JABElement(object):
             AccessibleTableInfo: Accessible Table Info.
         """
         info = AccessibleTableInfo()
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getAccessibleTableRowHeader(
             self.vmid, accessible_context, byref(info)
         )
@@ -504,9 +478,7 @@ class JABElement(object):
             AccessibleTableInfo: Accessible Table Info.
         """
         info = AccessibleTableInfo()
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getAccessibleTableColumnHeader(
             self.vmid, accessible_context, byref(info)
         )
@@ -527,9 +499,7 @@ class JABElement(object):
         Returns:
             int: Accessible table row selection count.
         """
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         return self.bridge.getAccessibleTableRowSelectionCount(
             self.vmid, accessible_context
         )
@@ -545,9 +515,7 @@ class JABElement(object):
         Returns:
             int: Accessible table column selection count.
         """
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         return self.bridge.getAccessibleTableColumnSelectionCount(
             self.vmid, accessible_context
         )
@@ -569,9 +537,7 @@ class JABElement(object):
             AccessibleTableCellInfo: Accessible Table Cell Info.
         """
         info = AccessibleTableCellInfo()
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getAccessibleTableCellInfo(
             self.vmid, accessible_context, row, column, byref(info)
         )
@@ -590,9 +556,7 @@ class JABElement(object):
         Returns:
             int: [description]
         """
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getVisibleChildrenCount(self.vmid, accessible_context)
         if result == -1:
             raise JABException(self.int_func_err_msg.format("getVisibleChildrenCount"))
@@ -602,9 +566,7 @@ class JABElement(object):
         self, accessible_context: JOBJECT64 = None
     ) -> VisibleChildenInfo:
         info = VisibleChildenInfo()
-        accessible_context = (
-            accessible_context if accessible_context else self.accessible_context
-        )
+        accessible_context = accessible_context or self.accessible_context
         result = self.bridge.getVisibleChildren(
             self.vmid, accessible_context, 0, byref(info)
         )
@@ -720,7 +682,7 @@ class JABElement(object):
         """
         if self.role_en_us != "scroll bar":
             raise JABException("JABElement is not 'scroll bar'")
-        is_horizontal = True if "horizontal" in self.states_en_us else False
+        is_horizontal = "horizontal" in self.states_en_us
         x = self.bounds["x"]
         y = self.bounds["y"]
         height = self.bounds["height"]
@@ -730,16 +692,13 @@ class JABElement(object):
         if to_bottom and is_horizontal:
             x = x + width - height - 5
             y = y + height / 2
-        # vertical scroll to bottom
-        elif to_bottom is True and is_horizontal is False:
+        elif to_bottom:
             x = x + width / 2
             y = y + height - width - 5
-        # horizontal scroll to top(left)
-        elif to_bottom is False and is_horizontal is True:
+        elif is_horizontal:
             x = x + height + 5
             y = y + height / 2
-        # vertical scroll to top
-        elif to_bottom is False and is_horizontal is False:
+        else:
             x = x + width / 2
             y = y + width + 5
         self.win32_utils._click_mouse(x=int(x), y=int(y), hold=hold)
@@ -758,7 +717,7 @@ class JABElement(object):
         """
         if self.role_en_us != "slider":
             raise JABException("JABElement is not 'slider'")
-        is_horizontal = True if "horizontal" in self.states_en_us else False
+        is_horizontal = "horizontal" in self.states_en_us
         x = self.bounds["x"]
         y = self.bounds["y"]
         height = self.bounds["height"]
@@ -768,15 +727,12 @@ class JABElement(object):
         if to_bottom and is_horizontal:
             x = x + width - 5
             y = y + height / 2
-        # vertical slide to bottom
-        elif to_bottom is True and is_horizontal is False:
+        elif to_bottom:
             x = x + width / 2
             y = y + height - 5
-        # horizontal slide to top(left)
-        elif to_bottom is False and is_horizontal is True:
+        elif is_horizontal:
             y = y + height / 2
-        # vertical slide to top
-        elif to_bottom is False and is_horizontal is False:
+        else:
             x = x + width / 2
         self.win32_utils._click_mouse(x=int(x), y=int(y), hold=hold)
 
@@ -913,7 +869,7 @@ class JABElement(object):
         self._do_accessible_action(action=action)
 
     def expand(self, simulate: bool = False) -> None:
-        if "expandable" not in self._states_en_us:
+        if "expandable" not in self.states_en_us:
             raise JABException("JABElement does not support 'expand'")
         if simulate:
             self.click(simulate=True)
@@ -1090,8 +1046,7 @@ class JABElement(object):
         if attr_val[0] in ["'", '"'] and attr_val[-1] in ["'", '"']:
             attr_val = attr_val[1:-1]
         pattern = re.compile("^contains\([\"'](.*?)[\"']\)")
-        content = pattern.findall(attr_val)
-        if content:
+        if content := pattern.findall(attr_val):
             return content[0] in jabelement.name
         else:
             return attr_val == jabelement.name
@@ -1109,8 +1064,7 @@ class JABElement(object):
         if attr_val[0] in ["'", '"'] and attr_val[-1] in ["'", '"']:
             attr_val = attr_val[1:-1]
         pattern = re.compile("^contains\([\"'](.*?)[\"']\)")
-        content = pattern.findall(attr_val)
-        if content:
+        if content := pattern.findall(attr_val):
             return content[0] in jabelement.description
         else:
             return attr_val == jabelement.description
@@ -1128,11 +1082,8 @@ class JABElement(object):
         if attr_val[0] in ["'", '"'] and attr_val[-1] in ["'", '"']:
             attr_val = attr_val[1:-1]
         pattern = re.compile("^contains\([\"'](.*?)[\"']\)")
-        content = pattern.findall(attr_val)
-        if content:
-            return all(
-                [stat in jabelement.states_en_us for stat in content[0].split(",")]
-            )
+        if content := pattern.findall(attr_val):
+            return all(stat in jabelement.states_en_us for stat in content[0].split(","))
         else:
             return set(attr_val.split(",")) == set(jabelement.states_en_us)
 
@@ -1219,23 +1170,15 @@ class JABElement(object):
         Returns:
             JABElement: Node JABElement
         """
-        jabelement = (
-            jabelement
-            if jabelement
-            else JABElement(self.bridge, self.hwnd, self.vmid, self.accessible_context)
-        )
+        jabelement = jabelement or JABElement(self.bridge, self.hwnd, self.vmid, self.accessible_context)
         is_same = self._is_same_object(
             self.accessible_context, jabelement.accessible_context
         )
-        if is_same:
-            top_object = self._get_top_level_object(self.accessible_context)
-            is_top_level = self._is_same_object(self.accessible_context, top_object)
-            if is_top_level:
-                return jabelement
-            else:
-                return self.parent
-        else:
+        if not is_same:
             return jabelement
+        top_object = self._get_top_level_object(self.accessible_context)
+        is_top_level = self._is_same_object(self.accessible_context, top_object)
+        return jabelement if is_top_level else self.parent
 
     def _get_element_by_node(
         self,
@@ -1348,21 +1291,8 @@ class JABElement(object):
             raise JABException("incorrect by strategy '{}'".format(by))
         if by == By.XPATH:
             self.find_element_by_xpath(value=value, visible=visible)
-        located_element = None
         for jabelement in self._generate_all_childs(visible=visible):
-            is_matched = any(
-                [
-                    value is None,
-                    by == By.NAME and jabelement.name == value,
-                    by == By.DESCRIPTION and jabelement.description == value,
-                    by == By.STATES and set(jabelement.states_en_us) == set(value),
-                    by == By.OBJECT_DEPTH and jabelement.object_depth == int(value),
-                    by == By.CHILDREN_COUNT and jabelement.children_count == int(value),
-                    by == By.INDEX_IN_PARENT
-                    and jabelement.index_in_parent == int(value),
-                ]
-            )
-            if is_matched:
+            if self._is_element_matched(by=by, value=value, jabelement=jabelement):
                 located_element = jabelement
                 break
             self.release_jabelement(jabelement)
@@ -1512,7 +1442,7 @@ class JABElement(object):
         node_role = node_info.get("role")
         node_attributes = node_info.get("attributes")
         jabelement = self._get_node_element(jabelement)
-        jabelements = list()
+        jabelements = []
         for _jabelement in dict_gen[level](jabelement=jabelement, visible=visible):
             if node_role not in ["*", _jabelement.role_en_us]:
                 self.release_jabelement(_jabelement)
@@ -1547,8 +1477,8 @@ class JABElement(object):
             level: str,
             parent_jabelements: list[JABElement],
             visible: bool = False,
-        ) -> list(JABElement):
-            child_jabelements = list()
+        ) -> list[JABElement]:
+            child_jabelements = []
             for parent_jabelement in parent_jabelements:
                 jabelements = self._get_elements_by_node(
                     node=node,
@@ -1599,21 +1529,9 @@ class JABElement(object):
             raise JABException("incorrect by strategy '{}'".format(by))
         if by == By.XPATH:
             self.find_elements_by_xpath(value=value, visible=visible)
-        jabelements = list()
+        jabelements = []
         for jabelement in self._generate_all_childs(visible=visible):
-            is_matched = any(
-                [
-                    value is None,
-                    by == By.NAME and jabelement.name == value,
-                    by == By.DESCRIPTION and jabelement.description == value,
-                    by == By.STATES and set(jabelement.states_en_us) == set(value),
-                    by == By.OBJECT_DEPTH and jabelement.object_depth == int(value),
-                    by == By.CHILDREN_COUNT and jabelement.children_count == int(value),
-                    by == By.INDEX_IN_PARENT
-                    and jabelement.index_in_parent == int(value),
-                ]
-            )
-            if is_matched:
+            if self._is_element_matched(by=by, value=value, jabelement=jabelement):
                 jabelements.append(jabelement)
                 continue
             self.release_jabelement(jabelement)
@@ -1622,6 +1540,23 @@ class JABElement(object):
                 "no JABElement found by '{}' with locator '{}'".format(by, value)
             )
         return jabelements
+
+    @staticmethod
+    def _is_element_matched(jabelement: JABElement, by: str, value: Optional[str]):
+        return any(
+                [
+                    value is None,
+                    by == By.NAME and jabelement.name == value,
+                    by == By.DESCRIPTION and jabelement.description == value,
+                    by == By.STATES and set(jabelement.states_en_us) == set(value),
+                    by == By.OBJECT_DEPTH
+                    and jabelement.object_depth == int(value),
+                    by == By.CHILDREN_COUNT
+                    and jabelement.children_count == int(value),
+                    by == By.INDEX_IN_PARENT
+                    and jabelement.index_in_parent == int(value),
+                ]
+            )
 
     @property
     def size(self) -> dict:
@@ -1661,7 +1596,7 @@ class JABElement(object):
         y = self.bounds.get("y")
         width = self.bounds.get("width")
         height = self.bounds.get("height")
-        im = ImageGrab.grab(
+        return ImageGrab.grab(
             bbox=(
                 x,
                 y,
@@ -1671,7 +1606,6 @@ class JABElement(object):
             include_layered_windows=False,
             all_screens=True,
         )
-        return im
 
     @property
     def parent(self):

--- a/pyjab/jabfixedfunc.py
+++ b/pyjab/jabfixedfunc.py
@@ -21,7 +21,7 @@ from pyjab.accessibleinfo import AccessibleTextInfo
 from pyjab.accessibleinfo import AccessibleTextItemsInfo
 from pyjab.accessibleinfo import AccessibleTextRectInfo
 from pyjab.accessibleinfo import AccessibleTextSelectionInfo
-from pyjab.accessibleinfo import VisibleChildenInfo
+from pyjab.accessibleinfo import VisibleChildrenInfo
 from pyjab.common.logger import Logger
 from pyjab.common.types import JOBJECT64
 
@@ -337,6 +337,6 @@ class JABFixedFunc(object):
             c_long,
             JOBJECT64,
             c_int,
-            POINTER(VisibleChildenInfo),
+            POINTER(VisibleChildrenInfo),
             errorcheck=True,
         )


### PR DESCRIPTION
* Inlining where sensible for return values
* Init lists with [] rather than list()
* Simplify if/else statements to return sooner when further logic not needed
* Use or instead of if/else where possible
* Using Walrus operator to improve readability where possible (requires Python 3.8+, but this is defined as such in setup.py already)
* Typos
* Remove unnecessary initialisations of objects
* Assignments that then had a break in the for loop and then returned simplified to simply return inside the loop
* Some type-hint fixes for multiple allowed types