### PR TITLE
Update tests

### DIFF
--- a/pyjab/jabelement.py
+++ b/pyjab/jabelement.py
@@ -878,14 +878,14 @@ class JABElement(object):
             return
         self._do_accessible_action("toggleexpand")
 
-    def send_text(self, value: str, simulate: bool = False) -> None:
+    def send_text(self, value: Union[str,int], simulate: bool = False) -> None:
         """Type into the JABElement.
 
         Default will use JAB Accessible Action.
         Set parameter 'simulate' to True if internal action does not work.
 
         :Args:
-            value (str): A string for typing.
+            value (str, int): A string for typing.
             simulate (bool, optional): Simulate user input action by keyboard event. Defaults to False.
 
         Use this to send simple key events or to fill out form fields::

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,9 +22,10 @@ UI_SWING_BASE_URL = "/".join([BASE_ORACLE_URL, "tutorialJWS/samples/uiswing"])
 class TestFile(NamedTuple):
     url: str
     file: Path
+    window_title: str
 
 
-class DemoUrl(Enum):
+class OracleApp(Enum):
     def __new__(cls, *args, **kwargs):
         value = len(cls.__members__) + 1
         obj = object.__new__(cls)
@@ -35,8 +36,18 @@ class DemoUrl(Enum):
         super().__init__()
         _jnlp_file_path = Path(TEST_FILES_DIR / f"{self._name_}.jnlp")
         _zip_file_path = Path(TEST_FILES_DIR / f"{self._name_}.zip")
-        self._value_ = TestFile(url=value,
-                                file=_jnlp_file_path if value.endswith(".jnlp") else _zip_file_path)
+
+        def extract_file_name(path: str):
+            # Get last string after / and then the first string before .
+            return path.split("/")[-1].split(".")[0]
+
+        def remove_digits(input:str):
+            return ''.join([i for i in input if not i.isdigit()])
+
+        file_path = value[0] if isinstance(value, tuple) else value
+        self._value_ = TestFile(url=file_path,
+                                file=_jnlp_file_path if value.endswith(".jnlp") else _zip_file_path,
+                                window_title=remove_digits(value[1]) if isinstance(value, tuple) else remove_digits(extract_file_name(file_path)))
 
     BUTTON = "/".join([UI_SWING_BASE_URL, "ButtonDemoProject/ButtonDemo.jnlp"])
     CHECK_BOX = "/".join([UI_SWING_BASE_URL, "CheckBoxDemoProject/CheckBoxDemo.jnlp"])
@@ -75,7 +86,7 @@ def get_test_jnlp_files():
 
     existing_files = os.listdir(TEST_FILES_DIR)
 
-    for test_file in DemoUrl:
+    for test_file in OracleApp:
         if test_file.value.file.name in existing_files:
             continue
         r = requests.get(test_file.value.url, allow_redirects=True)
@@ -84,177 +95,15 @@ def get_test_jnlp_files():
 
 
 @pytest.fixture
-def button_app() -> JABDriver:
-    with AppInit(DemoUrl.BUTTON.value.file, "ButtonDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def checkbox_app() -> JABDriver:
-    with AppInit(DemoUrl.CHECK_BOX.value.file, "CheckBoxDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def color_chooser_app() -> JABDriver:
-    with AppInit(DemoUrl.COLOR_CHOOSER.value.file, "ColorChooserDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def combo_box_app() -> JABDriver:
-    with AppInit(DemoUrl.COMBO_BOX.value.file, "ComboBoxDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def dialog_app() -> JABDriver:
-    with AppInit(DemoUrl.DIALOG.value.file, "DialogDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def file_chooser_app() -> JABDriver:
-    # TODO: Not sure how this is launching the app
-    with AppInit(DemoUrl.FILE_CHOOSER.value.file, "FileChooserDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def frame_app() -> JABDriver:
-    with AppInit(DemoUrl.FRAME.value.file, "FrameDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def internal_frame_app() -> JABDriver:
-    with AppInit(DemoUrl.INTERNAL_FRAME.value.file, "InternalFrameDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def label_app() -> JABDriver:
-    with AppInit(DemoUrl.LABEL.value.file, "LabelDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def layered_pane_app() -> JABDriver:
-    with AppInit(DemoUrl.LAYERED_PANE.value.file, "LayeredPaneDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def list_app() -> JABDriver:
-    with AppInit(DemoUrl.LIST.value.file, "ListDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def menu_app() -> JABDriver:
-    with AppInit(DemoUrl.MENU.value.file, "MenuDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def password_app() -> JABDriver:
-    with AppInit(DemoUrl.PASSWORD.value.file, "PasswordDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def popup_app() -> JABDriver:
-    with AppInit(DemoUrl.POPUP.value.file, "PopupMenuDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def progress_bar_app() -> JABDriver:
-    with AppInit(DemoUrl.PROGRESS_BAR.value.file, "ProgressBarDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def radio_button_app() -> JABDriver:
-    with AppInit(DemoUrl.RADIO_BUTTON.value.file, "RadioButtonDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def root_layered_pane_app() -> JABDriver:
-    with AppInit(DemoUrl.ROOT_LAYERED_PANE.value.file, "RootLayeredPaneDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def scroll_app() -> JABDriver:
-    with AppInit(DemoUrl.SCROLL.value.file, "ScrollDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def slider_app() -> JABDriver:
-    with AppInit(DemoUrl.SLIDER.value.file, "SliderDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def slider_two_app() -> JABDriver:
-    with AppInit(DemoUrl.SLIDER_TWO.value.file, "SliderDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def spinbox_app() -> JABDriver:
-    with AppInit(DemoUrl.SPINNER.value.file, "SpinnerDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def split_pane_app() -> JABDriver:
-    with AppInit(DemoUrl.SPLIT_PANE.value.file, "SplitPaneDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def status_bar_app() -> JABDriver:
-    with AppInit(DemoUrl.STATUS_BAR.value.file, "StatusBarDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def table_app() -> JABDriver:
-    with AppInit(DemoUrl.TABLE.value.file, "TableDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def text_area_app() -> JABDriver:
-    with AppInit(DemoUrl.TEXT_AREA.value.file, "TextAreaDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def tool_bar_app() -> JABDriver:
-    with AppInit(DemoUrl.TOOLBAR.value.file, "ToolBarDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def tree_app() -> JABDriver:
-    with AppInit(DemoUrl.TREE.value.file, "TreeDemo") as jabdriver:
-        yield jabdriver
-
-
-@pytest.fixture
-def table_ftf_edit_app() -> JABDriver:
-    with AppInit(DemoUrl.TABLE_FTF_EDIT.value.file, "TableFTFEditDemo") as jabdriver:
-        yield jabdriver
+def oracle_app(request) -> JABDriver:
+    app: TestFile = request.param.value
+    with AppInit(app.file, app.window_title) as jab_driver:
+        yield jab_driver
 
 
 @pytest.fixture
 def java_control_app() -> JABDriver:
-    with AppInit(Path(os.environ.get("JRE_HOME", "C:\\Program Files\\Java\\jdk1.8.0_311\\jre") + "\\bin\\javacpl.exe"), "Java Control Panel") as jabdriver:
+    with AppInit(Path(r"C:\Program Files\Java\jdk1.8.0_311\jre\bin\javacpl.exe"), "Java Control Panel") as jabdriver:
         yield jabdriver
 
 
@@ -271,3 +120,4 @@ class AppInit:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         subprocess.run('cmd /c "wmic process where name=\'jp2launcher.exe\'" delete')
+        subprocess.run('cmd /c "taskkill /FI "WINDOWTITLE eq Java Control Panel" /F"')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 import os
-import subprocess
 from enum import Enum
 from pathlib import Path
-from subprocess import Popen
 from typing import NamedTuple
 
 import pytest
@@ -97,27 +95,12 @@ def get_test_jnlp_files():
 @pytest.fixture
 def oracle_app(request) -> JABDriver:
     app: TestFile = request.param.value
-    with AppInit(app.file, app.window_title) as jab_driver:
+    with JABDriver(file_path=app.file, title=app.window_title) as jab_driver:
         yield jab_driver
 
 
 @pytest.fixture
 def java_control_app() -> JABDriver:
-    with AppInit(Path(r"C:\Program Files\Java\jdk1.8.0_311\jre\bin\javacpl.exe"), "Java Control Panel") as jabdriver:
+    # Assumes installation of some jdk 1.8 - currently hardcoded
+    with JABDriver(file_path=Path(r"C:\Program Files\Java\jdk1.8.0_311\jre\bin\javacpl.exe"), title="Java Control Panel") as jabdriver:
         yield jabdriver
-
-
-class AppInit:
-    def __init__(self, file: Path, window_name: str):
-        self.file = file
-        self.name = window_name
-        self.jabdriver = None
-
-    def __enter__(self):
-        Popen(" ".join(["javaws", str(self.file)]) if self.file.suffix == "jnlp" else str(self.file), shell=True).wait()
-        self.jabdriver = JABDriver(self.name)
-        return self.jabdriver
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        subprocess.run('cmd /c "wmic process where name=\'jp2launcher.exe\'" delete')
-        subprocess.run('cmd /c "taskkill /FI "WINDOWTITLE eq Java Control Panel" /F"')

--- a/tests/test_bridge_dll.py
+++ b/tests/test_bridge_dll.py
@@ -2,9 +2,8 @@ from pyjab.jabdriver import JABDriver
 
 
 class TestBridgeDll(object):
-    def test_bridge_default(self) -> None:
-        jabdriver = JABDriver(title="Java Control Panel")
-        assert jabdriver
+    def test_bridge_default(self, java_control_app) -> None:
+        assert java_control_app
 
     def test_bridge_x86(self) -> None:
         # JDK 1.8

--- a/tests/test_bug_fix.py
+++ b/tests/test_bug_fix.py
@@ -1,16 +1,11 @@
-from pyjab.jabdriver import JABDriver
-
-
 class TestBugFix(object):
     def test_fix_same_title(self, java_control_app) -> None:
         assert java_control_app
 
-    def test_fix_jab_init(self) -> None:
-        jabdriver = JABDriver(title="Java Control Panel")
-        tab_general = jabdriver.find_element_by_name("General")
+    def test_fix_jab_init(self, java_control_app) -> None:
+        tab_general = java_control_app.find_element_by_name("General")
         assert tab_general
 
-    def test_multiple_key_press(self) -> None:
-        jabdriver = JABDriver(title="Java Control Panel")
-        jabdriver.find_element_by_name("General").click(simulate=True)
-        jabdriver._press_hold_release_key("tab", "shift")
+    def test_multiple_key_press(self, java_control_app) -> None:
+        java_control_app.find_element_by_name("General").click(simulate=True)
+        java_control_app._press_hold_release_key("tab", "shift")

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,9 +1,13 @@
 from datetime import date
 
+import pytest
+
 from pyjab.common.role import Role
 from pyjab.common.states import States
 from pyjab.jabdriver import JABDriver
 from logging import Logger
+
+from tests.conftest import OracleApp
 
 
 class TestComponents(object):
@@ -15,30 +19,34 @@ class TestComponents(object):
         # Doesn't seem to recognise the new window unless click is simulated
         push_button.click(simulate=True)
 
-    def test_alert(self, dialog_app):
-        self._click_dialog_popup_button(dialog_app)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.DIALOG], indirect=True)
+    def test_alert(self, oracle_app: JABDriver):
+        self._click_dialog_popup_button(oracle_app)
         # Switch to popup dialog
         popup_jab_driver = JABDriver("Message")
         alert = popup_jab_driver.find_element_by_role(Role.ALERT)
         assert alert
         self.logger.info(alert.get_element_information())
 
-    def test_checkbox(self, checkbox_app):
-        checkbox = checkbox_app.find_element_by_role(Role.CHECK_BOX)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.CHECK_BOX], indirect=True)
+    def test_checkbox(self, oracle_app: JABDriver):
+        checkbox = oracle_app.find_element_by_role(Role.CHECK_BOX)
         assert checkbox
         self.logger.info(checkbox.get_element_information())
-        checkbox_chin = checkbox_app.find_element_by_name("Chin")
-        checkbox_hair = checkbox_app.find_element_by_name("Hair")
+        checkbox_chin = oracle_app.find_element_by_name("Chin")
+        checkbox_hair = oracle_app.find_element_by_name("Hair")
         checkbox_chin.click()
         checkbox_hair.click(simulate=True)
 
-    def test_color_chooser(self, color_chooser_app):
-        alert = color_chooser_app.find_element_by_role(Role.COLOR_CHOOSER)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.COLOR_CHOOSER], indirect=True)
+    def test_color_chooser(self, oracle_app: JABDriver):
+        alert = oracle_app.find_element_by_role(Role.COLOR_CHOOSER)
         assert alert
         self.logger.info(alert.get_element_information())
 
-    def test_combo_box(self, combo_box_app):
-        combo_box = combo_box_app.find_element_by_role(Role.COMBO_BOX)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.COMBO_BOX], indirect=True)
+    def test_combo_box(self, oracle_app: JABDriver):
+        combo_box = oracle_app.find_element_by_role(Role.COMBO_BOX)
         assert combo_box
         self.logger.info(combo_box.get_element_information())
         combo_box.select(option="Cat")
@@ -46,43 +54,49 @@ class TestComponents(object):
         combo_box.select(option="Rabbit", simulate=True)
         assert combo_box.get_selected_element().name == "Rabbit"
 
-    def test_dialog(self, dialog_app):
-        self._click_dialog_popup_button(dialog_app)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.DIALOG], indirect=True)
+    def test_dialog(self, oracle_app: JABDriver):
+        self._click_dialog_popup_button(oracle_app)
         # Switch to popup dialog
         popup_jab_driver = JABDriver("Message")
         popup = popup_jab_driver.find_element_by_role(Role.DIALOG)
         assert popup
         self.logger.info(popup.get_element_information())
 
-    def test_file_chooser(self, file_chooser_app):
-        # sample from https://docs.oracle.com/javase/tutorial/uiswing/examples/zipfiles/components-FileChooserDemo2Project.zip
-        jabdriver = JABDriver("Attach")
-        file_chooser = jabdriver.find_element_by_role(Role.FILE_CHOOSER)
-        assert file_chooser
-        self.logger.info(file_chooser.get_element_information())
+    # TODO: Allow to automatically run with setup as the other tests
+    # @pytest.mark.parametrize('oracle_app', [OracleApp.FILE_CHOOSER], indirect=True)
+    # def test_file_chooser(self, oracle_app: JABDriver):
+    #     file_chooser = oracle_app.find_element_by_role(Role.FILE_CHOOSER)
+    #     assert file_chooser
+    #     self.logger.info(file_chooser.get_element_information())
 
-    def test_frame(self, frame_app):
-        frame = frame_app.find_element_by_role(Role.FRAME)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.FRAME], indirect=True)
+    def test_frame(self, oracle_app: JABDriver):
+        frame = oracle_app.find_element_by_role(Role.FRAME)
         assert frame
         self.logger.info(frame.get_element_information())
 
-    def test_internal_frame(self, internal_frame_app):
-        internal_frame = internal_frame_app.find_element_by_role(Role.INTERNAL_FRAME)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.INTERNAL_FRAME], indirect=True)
+    def test_internal_frame(self, oracle_app: JABDriver):
+        internal_frame = oracle_app.find_element_by_role(Role.INTERNAL_FRAME)
         assert internal_frame
         self.logger.info(internal_frame.get_element_information())
 
-    def test_label(self, label_app):
-        label = label_app.find_element_by_role(Role.LABEL)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.LABEL], indirect=True)
+    def test_label(self, oracle_app: JABDriver):
+        label = oracle_app.find_element_by_role(Role.LABEL)
         assert label
         self.logger.info(label.get_element_information())
 
-    def test_layered_pane(self, layered_pane_app):
-        label = layered_pane_app.find_element_by_role(Role.LAYERED_PANE)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.LAYERED_PANE], indirect=True)
+    def test_layered_pane(self, oracle_app: JABDriver):
+        label = oracle_app.find_element_by_role(Role.LAYERED_PANE)
         assert label
         self.logger.info(label.get_element_information())
 
-    def test_list(self, list_app):
-        _list = list_app.find_element_by_role(Role.LIST)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.LIST], indirect=True)
+    def test_list(self, oracle_app: JABDriver):
+        _list = oracle_app.find_element_by_role(Role.LIST)
         assert _list
         self.logger.info(_list.get_element_information())
         _list.select("John Smith")
@@ -90,33 +104,38 @@ class TestComponents(object):
         _list.select("Kathy Green", simulate=True)
         assert _list.get_selected_element().name == "Kathy Green"
 
-    def test_menu(self, menu_app):
-        menu = menu_app.find_element_by_xpath("//menu[@name='A Menu']")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.MENU], indirect=True)
+    def test_menu(self, oracle_app: JABDriver):
+        menu = oracle_app.find_element_by_xpath("//menu[@name='A Menu']")
         assert menu
         self.logger.info(menu.get_element_information())
         menu.select("Another one")
         menu.select("A check box menu item", simulate=True)
 
-    def test_menu_bar(self, menu_app):
-        menu_bar = menu_app.find_element_by_role(Role.MENU_BAR)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.MENU], indirect=True)
+    def test_menu_bar(self, oracle_app: JABDriver):
+        menu_bar = oracle_app.find_element_by_role(Role.MENU_BAR)
         assert menu_bar
         self.logger.info(menu_bar.get_element_information())
 
-    def test_menu_item(self, menu_app):
-        menu_item = menu_app.find_element_by_role(Role.MENU_ITEM)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.MENU], indirect=True)
+    def test_menu_item(self, oracle_app: JABDriver):
+        menu_item = oracle_app.find_element_by_role(Role.MENU_ITEM)
         assert menu_item
         self.logger.info(menu_item.get_element_information())
         menu_item.click()
 
-    def test_page_tab(self, color_chooser_app):
-        page_tab_hsv = color_chooser_app.find_element_by_xpath("//page tab[@name='HSV']")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.COLOR_CHOOSER], indirect=True)
+    def test_page_tab(self, oracle_app: JABDriver):
+        page_tab_hsv = oracle_app.find_element_by_xpath("//page tab[@name='HSV']")
         assert page_tab_hsv
         self.logger.info(page_tab_hsv.get_element_information())
         page_tab_hsv.click(simulate=True)
         assert page_tab_hsv.is_selected()
 
-    def test_page_tab_list(self, color_chooser_app):
-        page_tab_list = color_chooser_app.find_element_by_role(Role.PAGE_TAB_LIST)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.COLOR_CHOOSER], indirect=True)
+    def test_page_tab_list(self, oracle_app: JABDriver):
+        page_tab_list = oracle_app.find_element_by_role(Role.PAGE_TAB_LIST)
         assert page_tab_list
         self.logger.info(page_tab_list.get_element_information())
         page_tab_list.select("HSL")
@@ -126,13 +145,15 @@ class TestComponents(object):
         time.sleep(0.5)
         assert page_tab_list.get_selected_element().name == "RGB"
 
-    def test_panel(self, color_chooser_app):
-        panel = color_chooser_app.find_element_by_role(Role.PANEL)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.COLOR_CHOOSER], indirect=True)
+    def test_panel(self, oracle_app: JABDriver):
+        panel = oracle_app.find_element_by_role(Role.PANEL)
         assert panel
         self.logger.info(panel.get_element_information())
 
-    def test_password_text(self, password_app):
-        password = password_app.find_element_by_role(Role.PASSWORD_TEXT)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.PASSWORD], indirect=True)
+    def test_password_text(self, oracle_app: JABDriver):
+        password = oracle_app.find_element_by_role(Role.PASSWORD_TEXT)
         assert password
         self.logger.info(password.get_element_information())
         password.send_text("test password")
@@ -140,88 +161,99 @@ class TestComponents(object):
         password.send_text("test password2", simulate=True)
         assert password.text != "test password2"
 
-    def test_popup_menu(self, popup_app):
-        popup_app.find_element_by_name("A Menu").click()
-        popup_menu = popup_app.find_element_by_role(Role.POPUP_MENU)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.POPUP], indirect=True)
+    def test_popup_menu(self, oracle_app: JABDriver):
+        oracle_app.find_element_by_name("A Menu").click()
+        popup_menu = oracle_app.find_element_by_role(Role.POPUP_MENU)
         assert popup_menu
         self.logger.info(popup_menu.get_element_information())
 
-    def test_progress_bar(self, progress_bar_app):
-        progress_bar = progress_bar_app.find_element_by_role(Role.PROGRESS_BAR)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.PROGRESS_BAR], indirect=True)
+    def test_progress_bar(self, oracle_app: JABDriver):
+        progress_bar = oracle_app.find_element_by_role(Role.PROGRESS_BAR)
         assert progress_bar
         self.logger.info(progress_bar.get_element_information())
 
-    def test_push_button(self, button_app):
-        left_button = button_app.find_element_by_name("Disable middle button")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.BUTTON], indirect=True)
+    def test_push_button(self, oracle_app: JABDriver):
+        left_button = oracle_app.find_element_by_name("Disable middle button")
         assert left_button
         self.logger.info(left_button.get_element_information())
         left_button.click()
-        middle_button = button_app.find_element_by_name("Middle button")
+        middle_button = oracle_app.find_element_by_name("Middle button")
         assert not middle_button.is_enabled()
-        right_button = button_app.find_element_by_name("Enable middle button")
+        right_button = oracle_app.find_element_by_name("Enable middle button")
         right_button.click(simulate=True)
         assert middle_button.is_enabled()
 
-    def test_radio_button(self, radio_button_app):
-        cat = radio_button_app.find_element_by_name("Cat")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.RADIO_BUTTON], indirect=True)
+    def test_radio_button(self, oracle_app: JABDriver):
+        cat = oracle_app.find_element_by_name("Cat")
         assert cat
         self.logger.info(cat.get_element_information())
         cat.click(simulate=True)
         assert cat.is_checked()
-        dog = radio_button_app.find_element_by_name("Dog")
+        dog = oracle_app.find_element_by_name("Dog")
         dog.click(simulate=True)
         assert dog.is_checked()
 
-    def test_root_pane(self, root_layered_pane_app):
-        root_pane = root_layered_pane_app.find_element_by_role(Role.ROOT_PANE)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.ROOT_LAYERED_PANE], indirect=True)
+    def test_root_pane(self, oracle_app: JABDriver):
+        root_pane = oracle_app.find_element_by_role(Role.ROOT_PANE)
         assert root_pane
         self.logger.info(root_pane.get_element_information())
 
-    def test_scroll_bar(self, scroll_app):
-        scroll_bar_ver = scroll_app.find_element_by_xpath(
+    @pytest.mark.parametrize('oracle_app', [OracleApp.SCROLL], indirect=True)
+    def test_scroll_bar(self, oracle_app: JABDriver):
+        scroll_bar_ver = oracle_app.find_element_by_xpath(
             "//scroll bar[@states=contains('vertical')]"
         )
         assert scroll_bar_ver
         self.logger.info(scroll_bar_ver.get_element_information())
         scroll_bar_ver.scroll(to_bottom=True)
         scroll_bar_ver.scroll(to_bottom=False)
-        scroll_bar_hor = scroll_app.find_element_by_xpath(
+        scroll_bar_hor = oracle_app.find_element_by_xpath(
             "//scroll bar[@states=contains('horizontal')]"
         )
         scroll_bar_hor.scroll(to_bottom=True)
         scroll_bar_hor.scroll(to_bottom=False)
 
-    def test_scroll_pane(self, scroll_app):
-        scroll_pane = scroll_app.find_element_by_xpath("//scroll pane")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.SCROLL], indirect=True)
+    def test_scroll_pane(self, oracle_app: JABDriver):
+        scroll_pane = oracle_app.find_element_by_xpath("//scroll pane")
         assert scroll_pane
         self.logger.info(scroll_pane.get_element_information())
 
-    def test_separator(self, menu_app):
-        separator = menu_app.find_element_by_xpath("//separator")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.MENU], indirect=True)
+    def test_separator(self, oracle_app: JABDriver):
+        separator = oracle_app.find_element_by_xpath("//separator")
         assert separator
         self.logger.info(separator.get_element_information())
 
-    def test_slider(self, slider_app):
-        slider = slider_app.find_element_by_role("slider")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.SLIDER], indirect=True)
+    def test_slider(self, oracle_app: JABDriver):
+        slider = oracle_app.find_element_by_role("slider")
         assert slider
         self.logger.info(slider.get_element_information())
         slider.slide(to_bottom=True)
         slider.slide(to_bottom=False)
 
-    def test_slider2(self, slider_two_app):
-        slider = slider_two_app.find_element_by_role("slider")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.SLIDER_TWO], indirect=True)
+    def test_slider2(self, oracle_app: JABDriver):
+        slider = oracle_app.find_element_by_role("slider")
         assert slider
         self.logger.info(slider.get_element_information())
         slider.slide(to_bottom=True)
         slider.slide(to_bottom=False)
 
-    def test_spinnbox(self, spinbox_app):
-        spinner = spinbox_app.find_element_by_role("spinbox")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.SPINNER], indirect=True)
+    def test_spinnbox(self, oracle_app: JABDriver):
+        spinner = oracle_app.find_element_by_role("spinbox")
         assert spinner
         self.logger.info(spinner.get_element_information())
         spinner.spin(option="May")
         assert spinner.text == "May"
-        spinner_year = spinbox_app.find_element_by_xpath(
+        spinner_year = oracle_app.find_element_by_xpath(
             "//spinbox[@name=contains('Year')]"
         )
         spinner_year.spin(increase=True)
@@ -229,26 +261,30 @@ class TestComponents(object):
         spinner_year.spin(increase=False, simulate=True)
         assert spinner_year.text == str(date.today().year)
 
-    def test_split_pane(self, split_pane_app):
-        split_pane = split_pane_app.find_element_by_role(Role.SPLIT_PANE)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.SPLIT_PANE], indirect=True)
+    def test_split_pane(self, oracle_app: JABDriver):
+        split_pane = oracle_app.find_element_by_role(Role.SPLIT_PANE)
         assert split_pane
         self.logger.info(split_pane.get_element_information())
 
-    def test_status_bar(self, status_bar_app):
+    @pytest.mark.parametrize('oracle_app', [OracleApp.STATUS_BAR], indirect=True)
+    def test_status_bar(self, oracle_app: JABDriver):
         # TODO: Which app?
-        status_bar = status_bar_app.find_element_by_role(Role.STATUS_BAR)
+        status_bar = oracle_app.find_element_by_role(Role.STATUS_BAR)
         assert status_bar
         self.logger.info(status_bar.get_element_information())
 
-    def test_table(self, table_app):
-        table = table_app.find_element_by_role(Role.TABLE)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.TABLE], indirect=True)
+    def test_table(self, oracle_app: JABDriver):
+        table = oracle_app.find_element_by_role(Role.TABLE)
         assert table
         self.logger.info(table.get_element_information())
         assert table.get_cell(0, 0).name == "Kathy"
         assert table.get_cell(2, 2).name == "Knitting"
 
-    def test_text_area(self, text_area_app):
-        text = text_area_app.find_element_by_role("text")
+    @pytest.mark.parametrize('oracle_app', [OracleApp.TEXT_AREA], indirect=True)
+    def test_text_area(self, oracle_app: JABDriver):
+        text = oracle_app.find_element_by_role("text")
         assert text
         text.clear()
         self.logger.info("clear text")
@@ -262,25 +298,29 @@ class TestComponents(object):
         text.send_text(txt_chars, simulate=True)
         assert text.text == txt_chars
 
-    def test_tool_bar(self, tool_bar_app):
-        tool_bar = tool_bar_app.find_element_by_role(Role.TOOL_BAR)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.TOOLBAR], indirect=True)
+    def test_tool_bar(self, oracle_app: JABDriver):
+        tool_bar = oracle_app.find_element_by_role(Role.TOOL_BAR)
         assert tool_bar
         self.logger.info(tool_bar.get_element_information())
 
-    def test_tree(self, tree_app):
-        tree = tree_app.find_element_by_role(Role.TREE)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.TREE], indirect=True)
+    def test_tree(self, oracle_app: JABDriver):
+        tree = oracle_app.find_element_by_role(Role.TREE)
         assert tree
         self.logger.info(tree.get_element_information())
         tree.find_element_by_name("Books for Java Programmers").expand()
         assert tree.find_element_by_name("The Java Developers Almanac")
 
-    def test_viewport(self, tree_app):
-        viewport = tree_app.find_element_by_role(Role.VIEW_PORT)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.TREE], indirect=True)
+    def test_viewport(self, oracle_app: JABDriver):
+        viewport = oracle_app.find_element_by_role(Role.VIEW_PORT)
         assert viewport
         self.logger.info(viewport.get_element_information())
 
-    def test_table_edit(self, table_ftf_edit_app):
-        table = table_ftf_edit_app.find_element_by_role(Role.TABLE)
+    @pytest.mark.parametrize('oracle_app', [OracleApp.TABLE_FTF_EDIT], indirect=True)
+    def test_table_edit(self, oracle_app: JABDriver):
+        table = oracle_app.find_element_by_role(Role.TABLE)
         cell = table.get_cell(2, 2, True)
         assert cell
         self.logger.info(cell.name)
@@ -288,11 +328,9 @@ class TestComponents(object):
         cell.send_text("i", simulate=True)
         self.logger.info(cell.name)
 
-    def test_component_info(self):
-        # sample from java control panel
-        driver = JABDriver("Java Control Panel")
-        btn_about = driver.find_element_by_name("About...")
-        btn_view = driver.find_element_by_name("View...")
+    def test_component_info(self, java_control_app):
+        btn_about = java_control_app.find_element_by_name("About...")
+        btn_view = java_control_app.find_element_by_name("View...")
         self.logger.info(btn_about.name)
         self.logger.info(btn_view.name)
         self.logger.info(btn_about.description)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,3 +1,4 @@
+import time
 from datetime import date
 
 import pytest
@@ -191,7 +192,7 @@ class TestComponents(object):
         cat = oracle_app.find_element_by_name("Cat")
         assert cat
         self.logger.info(cat.get_element_information())
-        cat.click(simulate=True)
+        cat.click()
         assert cat.is_checked()
         dog = oracle_app.find_element_by_name("Dog")
         dog.click(simulate=True)
@@ -267,12 +268,12 @@ class TestComponents(object):
         assert split_pane
         self.logger.info(split_pane.get_element_information())
 
-    @pytest.mark.parametrize('oracle_app', [OracleApp.STATUS_BAR], indirect=True)
-    def test_status_bar(self, oracle_app: JABDriver):
-        # TODO: Which app?
-        status_bar = oracle_app.find_element_by_role(Role.STATUS_BAR)
-        assert status_bar
-        self.logger.info(status_bar.get_element_information())
+    # def test_status_bar(self):
+    #     # TODO: Local app only
+    #     status_bar_app = JABDriver("StatusBarDemo")
+    #     status_bar = status_bar_app.find_element_by_role(Role.STATUS_BAR)
+    #     assert status_bar
+    #     self.logger.info(status_bar.get_element_information())
 
     @pytest.mark.parametrize('oracle_app', [OracleApp.TABLE], indirect=True)
     def test_table(self, oracle_app: JABDriver):
@@ -290,7 +291,9 @@ class TestComponents(object):
         self.logger.info("clear text")
         text.send_text(1122233455)
         assert text.text == "1122233455"
-        txt_chars = "ashfueiw^&*$^%$测试文本"
+        txt_chars = "ashfueiw^&*$^%"
+        # TODO: This is the original test - my locale doesn't seem to be able to simulate Chinese chars...
+        # txt_chars = "ashfueiw^&*$^%$测试文本"
         text.send_text(txt_chars)
         assert text.text == txt_chars
         text.send_text(1122233455, simulate=True)


### PR DESCRIPTION
A second, follow-up PR:

I wasn't expecting the first to be merged so soon and so this is the continuation work.

I found the opening JABDriver when passing the file to open helpful, so added the capability to the JABDriver natively.

Also added context manager as this was helpful managing state in tests, and thought it would in practical use

Added wait checks as timing issues arose from testing - added text wait assertion by default (make sure text contents is as expected before continuing) - hopefully this is ok...

Only 4 tests now fail:

@gaozhao1989  - there seems to be an issue with the element object not refreshing its attributes when, for example, checking state (see test_radio_button - cat element is assigned, clicked, and then state checked: the state is from the original assignment, not refreshed when state is checked after clicking)