### PR TITLE
Supports JDK16 and later versions

### DIFF
--- a/pyjab/common/service.py
+++ b/pyjab/common/service.py
@@ -10,6 +10,7 @@ from pyjab.config import A11Y_PROPS_CONTENT
 from pyjab.config import A11Y_PROPS_PATH
 from pyjab.config import JAB_BRIDGE_DLL
 from pyjab.config import JDK_BRIDGE_DLL
+from pyjab.config import JDKBEF16_BRIDGE_DLL
 from pyjab.config import JRE_BRIDGE_DLL
 
 
@@ -51,6 +52,7 @@ class Service(object):
         for dll in [
             str(bridge_dll),
             JDK_BRIDGE_DLL.format(dll_bit),
+            JDKBEF16_BRIDGE_DLL.format(dll_bit),
             JRE_BRIDGE_DLL.format(dll_bit),
             JAB_BRIDGE_DLL.format(dll_bit),
         ]:

--- a/pyjab/config.py
+++ b/pyjab/config.py
@@ -12,7 +12,8 @@ TIMEOUT = 30
 
 # set JAB dll
 WAB_DLL = "WindowsAccessBridge-{}.dll"
-JDK_BRIDGE_DLL = os.environ.get("JAVA_HOME", ".") + f"\\jre\\bin\\{WAB_DLL}"
+JDK_BRIDGE_DLL = os.environ.get("JAVA_HOME", ".") + f"\\bin\\{WAB_DLL}"
+JDKBEF16_BRIDGE_DLL = os.environ.get("JAVA_HOME", ".") + f"\\jre\\bin\\{WAB_DLL}"
 JRE_BRIDGE_DLL = os.environ.get("JRE_HOME", ".") + f"\\bin\\{WAB_DLL}"
 JAB_BRIDGE_DLL = os.environ.get("JAB_HOME", ".") + f"\\{WAB_DLL}"
 


### PR DESCRIPTION
Fix the problem of WindowsAccessBridge dll not found in jdk16+